### PR TITLE
Add version to `kinesis_firehose_connector` module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
 
 module "kinesis_firehose_connector" {
   source = "symopsio/kinesis-firehose-connector/sym"
+  version = ">= 1.0.0, < 2.0.0"
 
   environment = var.environment
   name_prefix = var.name_prefix


### PR DESCRIPTION
# Summary
- To ensure that this module will not break on major version updates of the `kinesis_firehose_connector` module, add a version.
- When `kinesis_firehose_connector` has a major version update, this version must be updated and this module will also release a major version