### PR TITLE
[SYM-4117] Pass tags from Firehose to Datadog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea/
 .vscode/
+
+*.tfvars
+*.terraform.lock.hcl
+.terraform/

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,18 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
     name       = "Datadog"
     access_key = var.datadog_access_key
     role_arn   = module.kinesis_firehose_connector.firehose_role_arn
+
+    request_configuration {
+      content_encoding = "GZIP"
+
+      dynamic "common_attributes" {
+        for_each = local.tags
+        content {
+          name  = common_attributes.key
+          value = common_attributes.value
+        }
+      }
+    }
   }
 
   tags = local.tags


### PR DESCRIPTION
# Summary
- We should pass [all tags applied to the Firehose Delivery Stream](https://docs.datadoghq.com/getting_started/tagging/) to Datadog
- This follows the setup [described in the Datadog docs](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination/?tab=kinesisfirehosedeliverystream)


# Testing
Terraform Plan example:
![Screen Shot 2022-09-09 at 8 26 03 AM](https://user-images.githubusercontent.com/10479740/189350140-44749f43-d294-443f-b324-c0578abc7649.png)


Tags in Datadog:
<img width="777" alt="Screen Shot 2022-09-09 at 9 00 39 AM" src="https://user-images.githubusercontent.com/10479740/189355726-244897c8-bf7e-4da2-b460-c884f1d9a267.png">

